### PR TITLE
Fixing and expanding on seeding and RNG

### DIFF
--- a/Assets/_BaristaGame/Prefabs/MainMenu/Arcade Mode.prefab
+++ b/Assets/_BaristaGame/Prefabs/MainMenu/Arcade Mode.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 182010811176636664}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -112,7 +111,6 @@ RectTransform:
   - {fileID: 2551649853897710370}
   - {fileID: 3040878467176606886}
   m_Father: {fileID: 5681431561661508134}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -330,7 +328,6 @@ RectTransform:
   - {fileID: 4908322994782415295}
   - {fileID: 4908322996275417594}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -369,7 +366,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8109557229898525198}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -545,7 +541,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3801295800392932041}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -723,7 +718,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 4611099931044957048}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -799,7 +793,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7190075801953826774}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -935,7 +928,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4611099931044957048}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1111,7 +1103,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6863311866321292080}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1290,7 +1281,6 @@ RectTransform:
   m_Children:
   - {fileID: 8501675765240610129}
   m_Father: {fileID: 9178702005801580947}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1367,7 +1357,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4046306164867708567}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1547,7 +1536,6 @@ RectTransform:
   m_Children:
   - {fileID: 5011314759917079193}
   m_Father: {fileID: 3433884523549178349}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1769,7 +1757,6 @@ RectTransform:
   - {fileID: 7257438684228005298}
   - {fileID: 4729163159762736965}
   m_Father: {fileID: 5681431561661508134}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1885,9 +1872,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 3146611017232018818}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 8299235689288805058}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1986,7 +1973,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1647377626593429216}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2122,7 +2108,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8578094748546527538}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2298,7 +2283,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6863311866321292080}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -2478,7 +2462,6 @@ RectTransform:
   - {fileID: 5643160842933609657}
   - {fileID: 5199941979595981894}
   m_Father: {fileID: 5681431561661508134}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2582,9 +2565,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 3146611017232018818}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 8299235689288805058}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2684,7 +2667,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 182010811176636664}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2860,7 +2842,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4046306164867708567}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3039,7 +3020,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9178702005801580947}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3217,7 +3197,6 @@ RectTransform:
   - {fileID: 2073731672738362328}
   - {fileID: 2834069150512645117}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3256,7 +3235,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4561210336378402930}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3433,7 +3411,6 @@ RectTransform:
   - {fileID: 5530614137152868117}
   - {fileID: 6018916649536380707}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3472,7 +3449,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6018916649536380707}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3648,7 +3624,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9178702005801580947}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -3823,7 +3798,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7056063518336395032}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3959,7 +3933,6 @@ RectTransform:
   m_Children:
   - {fileID: 8534578325992585228}
   m_Father: {fileID: 6863311866321292080}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4036,7 +4009,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3801295800392932041}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -4215,7 +4187,6 @@ RectTransform:
   m_Children:
   - {fileID: 3334204283471347626}
   m_Father: {fileID: 6863311866321292080}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4417,7 +4388,6 @@ RectTransform:
   m_Children:
   - {fileID: 738664330669287057}
   m_Father: {fileID: 3801295800392932041}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4494,7 +4464,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5592257789005324987}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4669,7 +4638,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2073731672738362328}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4808,7 +4776,6 @@ RectTransform:
   m_Children:
   - {fileID: 1172675811730639642}
   m_Father: {fileID: 3801295800392932041}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5013,7 +4980,6 @@ RectTransform:
   m_Children:
   - {fileID: 8552729672495225069}
   m_Father: {fileID: 1027653731830413323}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5214,7 +5180,6 @@ RectTransform:
   - {fileID: 1754986242250665572}
   - {fileID: 6583248806265451980}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5256,7 +5221,6 @@ RectTransform:
   m_Children:
   - {fileID: 8530115062550096066}
   m_Father: {fileID: 4046306164867708567}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5458,7 +5422,6 @@ RectTransform:
   m_Children:
   - {fileID: 6600049207392933736}
   m_Father: {fileID: 1027653731830413323}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5537,7 +5500,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322996240856295}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5795,7 +5757,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -6050,7 +6011,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -6127,7 +6087,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8109557229898525198}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6303,7 +6262,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995718061547}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6394,7 +6352,6 @@ RectTransform:
   - {fileID: 4046306164867708567}
   - {fileID: 9178702005801580947}
   m_Father: {fileID: 4908322995297578436}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6471,7 +6428,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6651,7 +6607,6 @@ RectTransform:
   - {fileID: 4908322996159552906}
   - {fileID: 4908322995073475029}
   m_Father: {fileID: 0}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6733,7 +6688,6 @@ RectTransform:
   m_Children:
   - {fileID: 4908322996296482796}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -6935,7 +6889,6 @@ RectTransform:
   m_Children:
   - {fileID: 4908322994877799196}
   m_Father: {fileID: 4908322996240856295}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7012,7 +6965,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322996275417594}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7187,7 +7139,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995297578436}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7267,7 +7218,6 @@ RectTransform:
   - {fileID: 4908322995718061547}
   - {fileID: 4908322994202777561}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7446,7 +7396,6 @@ RectTransform:
   m_Children:
   - {fileID: 4908322995785594561}
   m_Father: {fileID: 8109557229898525198}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7647,7 +7596,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995453930787}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7723,7 +7671,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 8578094748546527538}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7804,7 +7751,6 @@ RectTransform:
   - {fileID: 1299814192287671069}
   - {fileID: 2883199791837652061}
   m_Father: {fileID: 5681431561661508134}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -7908,9 +7854,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 3146611017232018818}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 8299235689288805058}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -8010,7 +7956,6 @@ RectTransform:
   m_Children:
   - {fileID: 5899895374338846648}
   m_Father: {fileID: 4046306164867708567}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8087,7 +8032,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2834069150512645117}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8263,7 +8207,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1027653731830413323}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -8439,7 +8382,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1610147276719130657}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8614,7 +8556,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5530614137152868117}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8751,7 +8692,6 @@ RectTransform:
   - {fileID: 1647377626593429216}
   - {fileID: 5143173311154400101}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8789,7 +8729,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 6583248806265451980}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8866,7 +8805,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5143173311154400101}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9043,7 +8981,6 @@ RectTransform:
   - {fileID: 7190075801953826774}
   - {fileID: 4561210336378402930}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9082,7 +9019,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1027653731830413323}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -9263,7 +9199,6 @@ RectTransform:
   - {fileID: 6505402364922879440}
   - {fileID: 3277394923231464958}
   m_Father: {fileID: 5681431561661508134}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -9367,9 +9302,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 3146611017232018818}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 8299235689288805058}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -9469,7 +9404,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5696113707795721708}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9644,7 +9578,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1754986242250665572}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -9720,7 +9653,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1610147276719130657}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -9801,7 +9733,6 @@ RectTransform:
   m_Children:
   - {fileID: 8137622731993181051}
   m_Father: {fileID: 3433884523549178349}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10042,7 +9973,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8299235689288805059}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -10182,7 +10112,6 @@ RectTransform:
   - {fileID: 4611099931044957048}
   - {fileID: 5696113707795721708}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -10261,7 +10190,6 @@ RectTransform:
   - {fileID: 7056063518336395032}
   - {fileID: 5592257789005324987}
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -10299,7 +10227,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 5696113707795721708}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -10375,7 +10302,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4908322995073475029}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -10455,7 +10381,6 @@ RectTransform:
   m_Children:
   - {fileID: 6921276891662635843}
   m_Father: {fileID: 9178702005801580947}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -10636,6 +10561,10 @@ PrefabInstance:
     - target: {fileID: 8771641084344376728, guid: 0795877fd390d5c4e97df8896d4c7508, type: 3}
       propertyPath: m_Name
       value: InputField (TMP) Seed
+      objectReference: {fileID: 0}
+    - target: {fileID: 8771641084344376728, guid: 0795877fd390d5c4e97df8896d4c7508, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8771641084344376729, guid: 0795877fd390d5c4e97df8896d4c7508, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/_BaristaGame/Prefabs/MainMenu/Canvas MainMenu.prefab
+++ b/Assets/_BaristaGame/Prefabs/MainMenu/Canvas MainMenu.prefab
@@ -14091,10 +14091,14 @@ PrefabInstance:
       objectReference: {fileID: 11400000, guid: 7659f6d6ec9b642db8be29bc45fe97cc, type: 2}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
@@ -14102,7 +14106,15 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 9120165736300685435}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 5305316552595781209}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
@@ -14110,7 +14122,15 @@ PrefabInstance:
       value: SetActive
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
       value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
@@ -14118,7 +14138,15 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 413423421098375587, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 929133800323252045, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
@@ -14211,11 +14239,11 @@ PrefabInstance:
       objectReference: {fileID: 11400000, guid: 7659f6d6ec9b642db8be29bc45fe97cc, type: 2}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
-      value: 3
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Target
@@ -14224,7 +14252,7 @@ PrefabInstance:
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_Target
       value: 
-      objectReference: {fileID: 3459876175346279896}
+      objectReference: {fileID: 5305316552595781209}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
       value: 2
@@ -14235,7 +14263,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
-      value: UnlockArchievement
+      value: SetActive
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
@@ -14243,11 +14271,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
-      value: ArchievementsHelper, Game
+      value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_IntArgument
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2906000003792654083, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_BoolArgument
@@ -14585,17 +14613,11 @@ PrefabInstance:
       addedObject: {fileID: 5110727856690589981}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
---- !u!114 &3459876175346279896 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 760959508816017731, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
+--- !u!1 &5305316552595781209 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8299235689288805058, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}
   m_PrefabInstance: {fileID: 4218900508455541915}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 884e514a75ca3e44a8b808c882040ce7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &9120165736300685435 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4908322996240856288, guid: 857bbe0394dde08409ffe28a6e630218, type: 3}

--- a/Assets/_BaristaGame/Scripts/Animation/BaristaController.cs
+++ b/Assets/_BaristaGame/Scripts/Animation/BaristaController.cs
@@ -279,7 +279,7 @@ public class BaristaController : MonoBehaviour
     {
         if (ChangeRandomSeed == true)
         {
-            BaristaAnimator.SetFloat(Consts.Random, Random.value);
+            BaristaAnimator.SetFloat(Consts.Random, Statics.GetRandomRange(0f, 1f));
         }
 
         CheckArchievemnt();

--- a/Assets/_BaristaGame/Scripts/Consts.cs
+++ b/Assets/_BaristaGame/Scripts/Consts.cs
@@ -97,6 +97,7 @@ public static class Consts
 
     //Etc Prefs
     public const string PlayerPrefRandomSeed = "RandomSeed";
+    public const string PlayerPrefCurrentSeed = "CurrentSeed";
     public const string PlayerPrefSceneWon = "SceneWon_";
 
     //Archievement

--- a/Assets/_BaristaGame/Scripts/Etc/SetSeed.cs
+++ b/Assets/_BaristaGame/Scripts/Etc/SetSeed.cs
@@ -5,28 +5,43 @@ public class SetSeed : MonoBehaviour
 {
     public TMP_InputField input;
 
-    private int newSeed;
+    private int chosenSeed;
     // Start is called before the first frame update
     void Start()
     {
-        newSeed = Statics.GetRandomRange(100, int.MaxValue);
-
-        if (input != null)
+        var chooseRandomSeed = true;
+        if(PlayerPrefs.HasKey(Consts.PlayerPrefRandomSeed))
         {
-            input.text = newSeed.ToString();
+            chosenSeed = PlayerPrefs.GetInt(Consts.PlayerPrefRandomSeed);
+            if(chosenSeed >= 0)
+            {
+                chooseRandomSeed = false;
+                PlayerPrefs.SetInt(Consts.PlayerPrefCurrentSeed, chosenSeed);
+            }
         }
-        SeedSet(newSeed.ToString());
+        if (chooseRandomSeed)
+        {
+            chosenSeed = Statics.GetRandomRange(0, int.MaxValue);
+            PlayerPrefs.SetInt(Consts.PlayerPrefCurrentSeed, chosenSeed);
+        }
+
+        input.text = chosenSeed.ToString();
     }
 
     public void SeedSet(string seed)
     {
         if (string.IsNullOrWhiteSpace(seed) == true)
         {
-            PlayerPrefs.SetInt(Consts.PlayerPrefRandomSeed, newSeed);
+            chosenSeed = Statics.GetRandomRange(0, int.MaxValue);
+            PlayerPrefs.SetInt(Consts.PlayerPrefRandomSeed, -1);
         }
         else
         {
-            PlayerPrefs.SetInt(Consts.PlayerPrefRandomSeed, Mathf.Abs(int.Parse(seed)));
+            chosenSeed = Mathf.Abs(int.Parse(seed));
+            PlayerPrefs.SetInt(Consts.PlayerPrefRandomSeed, chosenSeed);
         }
+        PlayerPrefs.SetInt(Consts.PlayerPrefCurrentSeed, chosenSeed);
+
+        input.text = chosenSeed.ToString();
     }
 }

--- a/Assets/_BaristaGame/Scripts/Etc/ShowSeedAsText.cs
+++ b/Assets/_BaristaGame/Scripts/Etc/ShowSeedAsText.cs
@@ -13,7 +13,7 @@ public class ShowSeedAsText : MonoBehaviour
         SeedText = GetComponent<TextMeshProUGUI>();
         if (SeedText != null)
         {
-            SeedText.text = PlayerPrefs.GetInt(Consts.PlayerPrefRandomSeed,-1).ToString();
+            SeedText.text = PlayerPrefs.GetInt(Consts.PlayerPrefCurrentSeed,-1).ToString();
         }
         else
         {

--- a/Assets/_BaristaGame/Scripts/Game/Events/EventBase.cs
+++ b/Assets/_BaristaGame/Scripts/Game/Events/EventBase.cs
@@ -85,7 +85,7 @@ public class EventBase : MonoBehaviour
     public void SetEventEndTime(float min, float max)
     {
         float curLevelTime = Time.timeSinceLevelLoad;
-        TimeEventEnd = Random.Range(curLevelTime + min, curLevelTime + max);
+        TimeEventEnd = Statics.GetRandomRange(curLevelTime + min, curLevelTime + max, Statics.EventDurationRNG());
     }
 
 

--- a/Assets/_BaristaGame/Scripts/Game/GameMode/BaseGameMode.cs
+++ b/Assets/_BaristaGame/Scripts/Game/GameMode/BaseGameMode.cs
@@ -167,6 +167,8 @@ public class BaseGameMode : MonoBehaviour
         soundEffectManager = SoundEffectManager.instance;
         statisticsHolder = StatisticsHolder.instance;
         baristaTalkManager = BaristaTalkManager.instance;
+
+        Statics.SeedMechanicalRNG(PlayerPrefs.GetInt(Consts.PlayerPrefCurrentSeed));
     }
 
     // Update is called once per frame

--- a/Assets/_BaristaGame/Scripts/Game/GameMode/GameMode_Arcade.cs
+++ b/Assets/_BaristaGame/Scripts/Game/GameMode/GameMode_Arcade.cs
@@ -84,7 +84,7 @@ public class GameMode_Arcade : BaseGameMode
 
     public void CalcNextTimeMilkyUpgrade()
     {
-        NextTimeUpgrade = Time.timeSinceLevelLoad + Random.Range(TimeUntilNextUpgradeMin, TimeUntilNextUpgradeMax);
+        NextTimeUpgrade = Time.timeSinceLevelLoad + Statics.GetRandomRange(TimeUntilNextUpgradeMin, TimeUntilNextUpgradeMax, Statics.MilkyRNG());
     }
 
     public void DoMilkyModeStepUp()

--- a/Assets/_BaristaGame/Scripts/Game/Manager/EventManager.cs
+++ b/Assets/_BaristaGame/Scripts/Game/Manager/EventManager.cs
@@ -151,7 +151,7 @@ public class EventManager : MonoBehaviour
             }
             else
             {
-                int rnd = Mathf.RoundToInt(UnityEngine.Random.Range(0, PossibileEvents.Count()));
+                int rnd = Statics.GetRandomRange(0, PossibileEvents.Count()-1, Statics.EventTypeRNG());
                 EventToStart = PossibileEvents[rnd];
             }
 
@@ -263,7 +263,7 @@ public class EventManager : MonoBehaviour
     [BurstCompile]
     private void SetNextEventTime()
     {
-        NextEventTime = Time.timeSinceLevelLoad + UnityEngine.Random.Range(MinTime, MaxTime) ;
+        NextEventTime = Time.timeSinceLevelLoad + Statics.GetRandomRange(MinTime, MaxTime, Statics.EventGapRNG());
     }
 
 }

--- a/Assets/_BaristaGame/Scripts/Game/Manager/OrderManager.cs
+++ b/Assets/_BaristaGame/Scripts/Game/Manager/OrderManager.cs
@@ -210,6 +210,8 @@ public class OrderManager : MonoBehaviour
         orderIsActive = true;
         ActiveCustomer = custom;
 
+        Statics.SeedSpecificDrinkRNG();
+
 
         //Need the Fulstered Value Before Generate the CUstomer because the text Generation
         //CurrentFlusteredLevel = CalcFlusteredLevel();
@@ -273,25 +275,25 @@ public class OrderManager : MonoBehaviour
                 fillingValues.Add(100);
                 break;
             case 2:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.twoFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.twoFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.twoFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.twoFillings[rndcnt].value2);
                 break;
             case 3:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.threeFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.threeFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.threeFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.threeFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.threeFillings[rndcnt].value3);
                 break;
             case 4:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.fourFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.fourFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.fourFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.fourFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.fourFillings[rndcnt].value3);
                 fillingValues.Add(PossibileFillingPercentages.fourFillings[rndcnt].value4);
                 break;
             case 5:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.fiveFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.fiveFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.fiveFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.fiveFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.fiveFillings[rndcnt].value3);
@@ -299,7 +301,7 @@ public class OrderManager : MonoBehaviour
                 fillingValues.Add(PossibileFillingPercentages.fiveFillings[rndcnt].value5);
                 break;
             case 6:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.sixFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.sixFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.sixFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.sixFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.sixFillings[rndcnt].value3);
@@ -308,7 +310,7 @@ public class OrderManager : MonoBehaviour
                 fillingValues.Add(PossibileFillingPercentages.sixFillings[rndcnt].value6);
                 break;
             case 7:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.sevenFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.sevenFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.sevenFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.sevenFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.sevenFillings[rndcnt].value3);
@@ -318,7 +320,7 @@ public class OrderManager : MonoBehaviour
                 fillingValues.Add(PossibileFillingPercentages.sevenFillings[rndcnt].value7);
                 break;
             case 8:
-                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.eightFillings.Length - 1);
+                rndcnt = Statics.GetRandomRange(0, PossibileFillingPercentages.eightFillings.Length - 1, Statics.SpecificDrinkRNG());
                 fillingValues.Add(PossibileFillingPercentages.eightFillings[rndcnt].value1);
                 fillingValues.Add(PossibileFillingPercentages.eightFillings[rndcnt].value2);
                 fillingValues.Add(PossibileFillingPercentages.eightFillings[rndcnt].value3);
@@ -516,7 +518,7 @@ public class OrderManager : MonoBehaviour
         }
         else
         {
-            return possibileOrder[Statics.GetRandomRange(0, possibileOrder.Count - 1)];
+            return possibileOrder[Statics.GetRandomRange(0, possibileOrder.Count - 1, Statics.SpecificDrinkRNG())];
         }
 
         //Debug.LogError("No Fitting Order Found!");
@@ -551,7 +553,6 @@ public class OrderManager : MonoBehaviour
 
         List<Fillings> generatedFillings = new List<Fillings>(); //this will be used to determine what will be added
 
-
         List<WeightedFillings> PossibileFillings = new List<WeightedFillings>();
         PossibileOrder possibileOrderCombo = GetPossibileOrderCombo(UnlockedFillings);
         if (possibileOrderCombo == null)
@@ -581,16 +582,16 @@ public class OrderManager : MonoBehaviour
         //int numChangedFillingsCount = 0;
         //bool canTopping = false;
 
-        byte minFillingCount = 0;
-        byte maxFillingCount = (byte)(PossibileFillings.Count);
-        byte minToppingCount = 0;
+        var minFillingCount = 0;
+        var maxFillingCount = PossibileFillings.Count;
+        var minToppingCount = 0;
         if (ChangedIngreedientCount != 0)
         {
             if (ChangedIngreedientCount > 0) //if the event wants more ingreedients
             {
                 if (ChangedIngreedientCount <= maxFillingCount)
                 {
-                    minFillingCount = (byte)ChangedIngreedientCount;
+                    minFillingCount = ChangedIngreedientCount;
                 }
                 else
                 {
@@ -602,7 +603,7 @@ public class OrderManager : MonoBehaviour
             {
                 if ( (ChangedIngreedientCount + maxFillingCount) > minToppingCount)
                 {
-                    maxFillingCount = (byte)(maxFillingCount + ChangedIngreedientCount);
+                    maxFillingCount = (maxFillingCount + ChangedIngreedientCount);
                 }
                 else
                 {
@@ -611,20 +612,16 @@ public class OrderManager : MonoBehaviour
             }
         }
 
+        int RandomCount = Statics.GetRandomRange(minFillingCount, maxFillingCount, Statics.SpecificDrinkRNG());
 
-        byte RandomCount = Statics.GetRandomRange(minFillingCount, maxFillingCount);
-        //int RandomCount = Random.Range(minFillingCount, maxFillingCount);
-        //Debug.Log("RandomCount: " + RandomCount + ", max: " + PossibileFillings.Count);
         if (RandomCount == 1 && PossibileFillings.Count == 1)
         {
-            //Debug.Log("Added: " + PossibileFillings[0].Filling);
             generatedFillings.Add(PossibileFillings[0].Filling);
         }
         else
         {
             for (int i = 0; i < RandomCount; i++)
             {
-                //int possibileFillingToAdd = Random.Range(0, PossibileFillings.Count);
                 int maxValue = 0;
                 for (int i2 = 0; i2 < PossibileFillings.Count; i2++)
                 {
@@ -632,9 +629,9 @@ public class OrderManager : MonoBehaviour
                 }
 
                 //Weighting
-                int result = 0; //Wich fill should be added value
+                int result = 0; //Which fill should be added value
                 int total = 0;
-                int randVal = Statics.GetRandomRange(0, maxValue+1);
+                int randVal = Statics.GetRandomRange(0, maxValue+1, Statics.SpecificDrinkRNG());
                 for (result = 0; result < PossibileFillings.Count; result++)
                 {
                     total += PossibileFillings[result].Weighting;
@@ -672,7 +669,7 @@ public class OrderManager : MonoBehaviour
                 }
             }
 
-            RandomCount = Statics.GetRandomRange(minToppingCount, (byte)(PossibileToppings.Count));
+            RandomCount = Statics.GetRandomRange(minToppingCount, PossibileToppings.Count, Statics.SpecificDrinkRNG());
 
             //Here work more
             if (RandomCount > 0)
@@ -688,7 +685,7 @@ public class OrderManager : MonoBehaviour
                     //Weighting
                     int result = 0; //Wich fill should be added value
                     int total = 0;
-                    int randVal = Statics.GetRandomRange(0, maxValue+1);
+                    int randVal = Statics.GetRandomRange(0, maxValue+1, Statics.SpecificDrinkRNG());
                     for (result = 0; result < PossibileFillings.Count; result++)
                     {
                         total += PossibileFillings[result].Weighting;
@@ -744,7 +741,7 @@ public class OrderManager : MonoBehaviour
             //Weighting
             int result = 0; //Wich fill should be added value
             int total = 0;
-            int randVal = Statics.GetRandomRange(0, maxValue + 1);
+            int randVal = Statics.GetRandomRange(0, maxValue + 1, Statics.SpecificDrinkRNG());
             for (result = 0; result < RandomCustomAvatars.Count; result++)
             {
                 total += RandomCustomAvatars[result].Stats.Weighted;
@@ -864,7 +861,7 @@ public class OrderManager : MonoBehaviour
 
         List<Fillings> OrderFillings = new List<Fillings>(ActiveCustomer.OrderFillings);
         OrderFillings.Remove(Fillings.BreastMilk);
-        OrderFillings.Shuffle();
+        OrderFillings.Shuffle(Statics.SpecificDrinkRNG());
 
 
         for (int i = 0; i < OrderFillings.Count+1; i++)
@@ -1037,7 +1034,7 @@ public class OrderManager : MonoBehaviour
         //Lets tryout the "Substract Method"
 
         //Shuffle Fillings to substract Randomly
-        OrderFillings.Shuffle();
+        OrderFillings.Shuffle(Statics.SpecificDrinkRNG());
 
         for (int i = 0; i < OrderFillings.Count; i++)
         {
@@ -1863,36 +1860,9 @@ public class OrderManager : MonoBehaviour
     }
 
     [BurstCompile]
-    public bool CheckIfFlustered()
-    {
-        if (isAlwaysFlustered == true || EventAlwaysFlustered == true )
-        {
-            return true;
-        }
-        else if (EventCustomerNotFlustered == true)
-        {
-            return false;
-        }
-
-        FlusteredChance = gamemode.Fullness + gamemode.TargetBustSize; //Fullness and MaxSize gives together 200
-        float rnd = Statics.GetRandom().NextFloat(0f, 175f); //the 175 here need maybe to adjust to depend the game difficulty
-        Debug.Log("Flustered Chance: " + FlusteredChance + " ? > " + rnd +  " || Fullness: " + gamemode.Fullness + " || BustSize: " + gamemode.TargetBustSize);
-
-        if (FlusteredChance > rnd)
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-
-    }
-
-    [BurstCompile]
     public int CalcFlusteredLevel(float multipler = 1f) //Depending on fullness?
     {
-        float randomNumber = ((gamemode.Fullness + gamemode.TargetBustSize) / 2 * multipler) * Statics.GetRandom().NextFloat(FlusteredRandomMultiplerMin, FlusteredRandomMultiplerMax);
+        float randomNumber = ((gamemode.Fullness + gamemode.TargetBustSize) / 2 * multipler) * Statics.GetRandomRange(FlusteredRandomMultiplerMin, FlusteredRandomMultiplerMax, Statics.SpecificDrinkRNG());
 
         if (randomNumber > FlusteredLevelActivationMin4)
         {


### PR DESCRIPTION
This pull request does three things:

1. Re-enable the seed entry box
2. Fix seeding functionality
3. Split RNG across several pools, each one specific to individual mechanics, such that behavior is more deterministic (i.e., the 10th event that the game tries to spawn will always be the same, and the 100th drink ordered will always be the same if you have the same unlocks at the time).
4. There are now two playerpref values governing seed: current seed and preferred seed. When the player manually enters a seed, both are set to equal the entered seed. This allows the game to remember the player's preferred seed. If the box is left blank, preferred seed is unset, and current seed becomes a random value.